### PR TITLE
require_relative in job_start

### DIFF
--- a/lib/chef/knife/job_start.rb
+++ b/lib/chef/knife/job_start.rb
@@ -15,7 +15,7 @@
 # under the License.
 #
 
-require "chef/knife/job_helpers"
+require_relative 'job_helpers'
 
 class Chef
   class Knife


### PR DESCRIPTION
### Description

In this pull request, the change made is to improve the way the file `'job_helpers'` is required by modifying the `require` statement in the file `lib/chef/knife/job_start.rb`.

The specific change can be summarized as follows:
- The `require` statement was updated from `"chef/knife/job_helpers"` to `require_relative 'job_helpers'` to improve the way the file is required.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace `require` with `require_relative` for loading `job_helpers` in `job_start.rb`.

### Why are these changes being made?

This change ensures that the `job_helpers` file is loaded relative to the location of `job_start.rb`, which improves file loading efficiency and reduces potential issues with load paths, especially in environments where the library path may not be set correctly. This approach is more robust for managing dependencies within the same directory.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->